### PR TITLE
2 minor multiplatform fixes (GL renderer and NaCl)

### DIFF
--- a/src/tb/renderers/tb_renderer_gl.cpp
+++ b/src/tb/renderers/tb_renderer_gl.cpp
@@ -5,9 +5,12 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include "tb_types.h"
 #include "tb_renderer_gl.h"
 #include "tb_bitmap_fragment.h"
 #include "tb_system.h"
+
+#if defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)
 
 namespace tb {
 
@@ -162,3 +165,4 @@ void TBRendererGL::SetClipRect(const TBRect &rect)
 }
 
 }; // namespace tb
+#endif // defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)

--- a/src/tb/renderers/tb_renderer_gl.h
+++ b/src/tb/renderers/tb_renderer_gl.h
@@ -6,6 +6,9 @@
 #ifndef TB_RENDERER_GL_H
 #define TB_RENDERER_GL_H
 
+#include "renderers/tb_renderer_batcher.h"
+
+#if defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)
 #ifdef TB_RENDERER_GLES_1
 #include <EGL/egl.h>
 #include <GLES/gl.h>
@@ -19,8 +22,6 @@
 #else
 #include <GL/gl.h>
 #endif
-
-#include "renderers/tb_renderer_batcher.h"
 
 namespace tb {
 
@@ -62,4 +63,5 @@ public:
 
 }; // namespace tb
 
+#endif // defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)
 #endif // TB_RENDERER_GL_H

--- a/src/tb/tb_list.cpp
+++ b/src/tb/tb_list.cpp
@@ -7,7 +7,9 @@
 #include "tb_core.h"
 #include <assert.h>
 #include <stdlib.h>
+#if !defined(__native_client__)
 #include <memory.h>
+#endif
 
 namespace tb {
 

--- a/src/tb/tb_tempbuffer.cpp
+++ b/src/tb/tb_tempbuffer.cpp
@@ -6,7 +6,9 @@
 #include "tb_tempbuffer.h"
 #include <assert.h>
 #include <stdlib.h>
+#if !defined(__native_client__)
 #include <memory.h>
+#endif
 #include <string.h>
 
 namespace tb {


### PR DESCRIPTION
These are 2 small fixes that allow turbobadger to be compiled on Native Client and on platforms that don't support legacy OpenGL APIs (e.g. glBegin/glEnd) by only including the sample GL renderer when enabled through tb_config.h defines.

Would be good if these changes could also go upstream eventually :)